### PR TITLE
Condense sidebar

### DIFF
--- a/site/_static/custom.css
+++ b/site/_static/custom.css
@@ -2,14 +2,6 @@
   margin-bottom: -1rem;
 }
 
-/* .bd-sidebar-primary {
-  overflow: auto;
-}
-
-.bd-sidebar {
-  overflow: auto;
-} */
-
 a {
   font-weight: bold;
 }

--- a/site/_static/custom.css
+++ b/site/_static/custom.css
@@ -1,43 +1,14 @@
-html .tabbed-set>label {
-  border-bottom: 0.125rem solid transparent;
-  color: grey;
-  cursor: pointer;
-  font-size: var(--tabs-size-label);
-  font-weight: 700;
-  padding: 1em 1.25em 0.5em;
-  transition: color 250ms;
-  width: auto;
-  z-index: 1;
-}
-
-.card {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  word-wrap: break-word;
-  background-color: #fff;
-  background-clip: border-box;
-  border: 1px solid rgba(0, 0, 0, .125);
-  border-radius: 0.5rem;
-  margin-bottom: 1rem;
-}
-
 .q-neg-margin {
   margin-bottom: -1rem;
 }
 
-:root[data-color-mode="dark"] {}
-
-.book-color-mode-toggle {}
-
-.bd-sidebar-primary {
+/* .bd-sidebar-primary {
   overflow: auto;
 }
 
 .bd-sidebar {
   overflow: auto;
-}
+} */
 
 a {
   font-weight: bold;
@@ -51,11 +22,6 @@ nav.bd-links {
   p.caption {
     margin-bottom: 0;
   }
-}
-
-.reference {
-  margin-top: 0;
-  padding-top: 0;
 }
 
 .caption-text {

--- a/site/_static/custom.css
+++ b/site/_static/custom.css
@@ -31,16 +31,31 @@ html .tabbed-set>label {
 
 .book-color-mode-toggle {}
 
-/* .bd-sidebar-primary {
+.bd-sidebar-primary {
   overflow: auto;
 }
 
 .bd-sidebar {
   overflow: auto;
-} */
+}
 
 a {
   font-weight: bold;
+}
+
+nav.bd-links {
+  li > a {
+    padding-left: 0.65rem;
+    padding-bottom: 0;
+  }
+  p.caption {
+    margin-bottom: 0;
+  }
+}
+
+.reference {
+  margin-top: 0;
+  padding-top: 0;
 }
 
 .caption-text {

--- a/site/_static/custom.js
+++ b/site/_static/custom.js
@@ -1,0 +1,7 @@
+document.addEventListener("DOMContentLoaded", function() {
+    var searchButton = document.getElementsByClassName("search-button-field")[0];
+    if (searchButton) {
+        var searchDiv = searchButton.parentNode;
+        searchDiv.style.display = "none";
+    }
+});


### PR DESCRIPTION
This PR is to condense the sidebar a little. Results on my 14" 3024x1964 :

<img width="653" alt="image" src="https://github.com/QCaudron/fieldday/assets/125310027/72943b0a-654f-4fee-9f36-70cd582584f7">

Specifically :
- clean up some old CSS that was there for the previous photo gallery; no longer needed
- remove CSS relating to the navbar; this was causing the lack of scrollbar, and was from a previous iteration
- add some JS to hide the search bar, because I can't find a config option to avoid displaying it