### PR TITLE
Pin jupyter-book to 1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-jupyter-book
+jupyter-book==1.0.4.post1
 pandas
 requests


### PR DESCRIPTION
PR 1 of 3 in series.

Otherwise, 2.0 will be installed and we'll be forced to upgrade to the 2.0 format.  We should do so, but that's not on the critical path for 2026.